### PR TITLE
#patch; switch prompt order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "A CLI for Messari Subgraph development.",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -114,7 +114,7 @@ module.exports = {
       type: 'select',
       name: 'service',
       message: 'Choose a service:',
-      choices: ['subgraph-studio', 'hosted-service', 'cronos-portal'],
+      choices: ['hosted-service', 'subgraph-studio', 'cronos-portal'],
       skip: !deploy,
     }
 


### PR DESCRIPTION
Switch the service prompt order. This is because hosted service is the most common and saves a keystroke to make it first :)