### PR TITLE
Support bridge schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.1.38",
+  "version": "0.1.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "messari-subgraph-cli",
-      "version": "0.1.38",
+      "version": "0.1.44",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^12.7.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "A CLI for Messari Subgraph development.",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/src/command-helpers/build/validateDeploymentJson.js
+++ b/src/command-helpers/build/validateDeploymentJson.js
@@ -45,6 +45,7 @@ function checkSchemaPresentAndValid(protocol, protocolData) {
       'erc721',
       'erc20',
       'nft-marketplace',
+      'bridge',
     ].includes(protocolData.schema)
   ) {
     throw new Error(


### PR DESCRIPTION
Build fails when trying to build a subgraph with the new Bridge schema

```
$ messari b multichain-mainnet
No deployment-id or protocol found for: multichain-mainnet
```