### PR TITLE
fix(#patch); update studio deploy args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.1.48",
+  "version": "0.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messari-subgraph-cli",
-      "version": "0.1.48",
+      "version": "0.1.50",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^12.7.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "A CLI for Messari Subgraph development.",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/src/command-helpers/build/scriptGenerator.ts
+++ b/src/command-helpers/build/scriptGenerator.ts
@@ -285,9 +285,9 @@ export class ScriptGenerator {
     switch (this.service) {
       case 'subgraph-studio':
         if (this.token) {
-          deploymentScript = `graph deploy --auth=${this.token} --product subgraph-studio ${location} --versionLabel ${version}`
+          deploymentScript = `graph deploy ${location} --studio --deploy-key=${this.token} --version-label=${version}`
         } else {
-          deploymentScript = `graph deploy --product subgraph-studio ${location} --version-label ${version}`
+          deploymentScript = `graph deploy ${location} --studio --version-label=${version}`
         }
         break
       case 'hosted-service':


### PR DESCRIPTION
The latest `@graphprotocol/graph-cli` version `0.42.4` has a different set of deployment args that we can utilize for the subgraph studio deployments. This PR updates those args in our tool.

New graph cli command:

```bash
graph deploy ${location} --studio --deploy-key=${this.token} --version-label=${version}
```

`messari-subgraph-cli` users will need to make sure to update their `@graphprotocol/graph-cli` to version `0.42.4` to ensure it works properly.