### PR TITLE
Add `metis` as a network type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A CLI for Messari Subgraph development.",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/src/command-helpers/build/validateDeploymentJson.js
+++ b/src/command-helpers/build/validateDeploymentJson.js
@@ -51,6 +51,7 @@ const networks = new Set([
   'osmo-test-4',
   'juno-1',
   'uni-3',
+  'unsupported',
 ])
 
 function checkSchemaPresentAndValid(protocol, protocolData) {

--- a/src/command-helpers/build/validateDeploymentJson.js
+++ b/src/command-helpers/build/validateDeploymentJson.js
@@ -51,6 +51,7 @@ const networks = new Set([
   'osmo-test-4',
   'juno-1',
   'uni-3',
+  'metis',
   'unsupported',
 ])
 


### PR DESCRIPTION
We now have a metis subgraph, and it is not supported on the graph, but suported on a hosted node from metis (andromeda)

Also adding `unsupported` for networks that are not supported here. It is a placeholder for a network until we add it here.