### PR TITLE
fix: use `--deploy-key` flag for authentication with the graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A CLI for Messari Subgraph development.",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/src/command-helpers/build/scriptGenerator.ts
+++ b/src/command-helpers/build/scriptGenerator.ts
@@ -290,13 +290,13 @@ export class ScriptGenerator {
         break
       case 'hosted-service':
         if (this.token) {
-          deploymentScript = `graph deploy --auth=${this.token} --product hosted-service ${location}`
+          deploymentScript = `graph deploy --deploy-key=${this.token} --product hosted-service ${location}`
         } else {
           deploymentScript = `graph deploy --product hosted-service ${location}`
         }
         break
       case 'cronos-portal':
-        deploymentScript = `graph deploy ${location} --access-token=${this.token} --node https://portal-api.cronoslabs.com/deploy --ipfs https://api.thegraph.com/ipfs --versionLabel=${version}`
+        deploymentScript = `graph deploy ${location} --deploy-key=${this.token} --node https://portal-api.cronoslabs.com/deploy --ipfs https://api.thegraph.com/ipfs --versionLabel=${version}`
         break
       default:
         throw new Error(


### PR DESCRIPTION
`graph`'s `--auth` and `--access-token` flags were deprecated since https://github.com/graphprotocol/graph-tooling/pull/1055

new flag is `--deploy-key`

closes #12 