### PR TITLE
add 'non-standard' to schema enums

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.1.52",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messari-subgraph-cli",
-      "version": "0.1.52",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^12.7.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messari-subgraph-cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A CLI for Messari Subgraph development.",
   "types": "build/types/types.d.ts",
   "bin": {

--- a/src/command-helpers/build/validateDeploymentJson.js
+++ b/src/command-helpers/build/validateDeploymentJson.js
@@ -77,6 +77,7 @@ function checkSchemaPresentAndValid(protocol, protocolData) {
       'bridge',
       'derivatives-perpfutures',
       'derivatives-options',
+      'non-standard',
     ].includes(protocolData.schema)
   ) {
     throw new Error(


### PR DESCRIPTION
`non-standard` enum shall be used for non-standardized subgraphs